### PR TITLE
Update buffer usage

### DIFF
--- a/src/scripts/server/psProxy.js
+++ b/src/scripts/server/psProxy.js
@@ -24,7 +24,7 @@ var proxyReqOptDecoratorFactory = function(tenantId, username, password) {
     let encodedHeader = null;
     if (username && username !== '' && password && password !== '') {
         var plainHeader = username + ':' + password;
-        encodedHeader = new Buffer(plainHeader).toString('base64');
+        encodedHeader = new Buffer.from(plainHeader, 'utf-8').toString('base64');
     }
 
     return function(proxyReq) {


### PR DESCRIPTION
- based on DeprecationWarning: Buffer() is deprecated due to security and usability issues.

Using the Buffer.from() implmentation